### PR TITLE
Tweaked code/quote matching regex to properly catch the intended markup.

### DIFF
--- a/modules/comments.py
+++ b/modules/comments.py
@@ -107,7 +107,8 @@ def search_line(data_token,lines):
 	logging.debug("Searching Line For Token")
 	for line in lines:
 #		logging.debug("Debug Comment Line: " + line)
-		if re.match("(    |&gt;)",line) is None: # Don't look in code or quotes
+		#NOTE: Markup should be at the start of the line, and shouldn't contain HTML entities like &gt;
+		if re.match("(^    |^>)",line) is None: # Don't look in code or quotes
 			for token in data_token: # Check each type of token
 				if token in line:
 					return token


### PR DESCRIPTION
Fixed an issue where tokens would be caught even if preceded by quote or code markup sequence. 

Since the data passed to search_line comes from `praw.objects.Comment.body`, the greater-than symbol shouldn't be html encoded. The only other change needed to make this work was to have the expression match the beginning of the line currently being searched, anything after a match is going to be interpreted as a code or quote on reddit's side. This was tested under python 2.7.11.


Signed-off-by: s33plusplus <s33plusplus@users.noreply.github.com>